### PR TITLE
Update ApRESDefs.py

### DIFF
--- a/xapres_package/ApRESDefs.py
+++ b/xapres_package/ApRESDefs.py
@@ -679,10 +679,7 @@ class DataFileObject:
             print("no local file found, trying remote load..")
             fs = gcsfs.GCSFileSystem()
             datafile = fs.open(self.Filename, mode='rb')
-            if 'datafile' is in locals():
-                print("remote load successful")
-            else:
-                print("remote load failed")
+            #TO-DO: could use a check to ensure datafile isn't empty
         except:
             print("file could not be found, see error message")
             

--- a/xapres_package/ApRESDefs.py
+++ b/xapres_package/ApRESDefs.py
@@ -674,11 +674,11 @@ class DataFileObject:
         
         # try to looad locally, then resort to loading remotely (would remove need for "remote" arg if propagated to rest of classes)
         try:
-            datafile = open(datafile, "rb")
+            datafile = open(self.Filename, "rb")
         except TypeError:
             print("no local file found, trying remote load..")
             fs = gcsfs.GCSFileSystem()
-            datafile = fs.open(datafile, mode='rb')
+            datafile = fs.open(self.Filename, mode='rb')
             if datafile is not None:
                 print("remote load successful")
             else:

--- a/xapres_package/ApRESDefs.py
+++ b/xapres_package/ApRESDefs.py
@@ -679,7 +679,7 @@ class DataFileObject:
             print("no local file found, trying remote load..")
             fs = gcsfs.GCSFileSystem()
             datafile = fs.open(self.Filename, mode='rb')
-            if datafile is not None:
+            if 'datafile' is in locals():
                 print("remote load successful")
             else:
                 print("remote load failed")

--- a/xapres_package/ApRESDefs.py
+++ b/xapres_package/ApRESDefs.py
@@ -672,12 +672,19 @@ class DataFileObject:
         self.Filename = Filename
         self.remote_load = remote_load
         
-
-        if remote_load:
+        # try to looad locally, then resort to loading remotely (would remove need for "remote" arg if propagated to rest of classes)
+        try:
+            datafile = open(datafile, "rb")
+        except TypeError:
+            print("no local file found, trying remote load..")
             fs = gcsfs.GCSFileSystem()
-            datafile = fs.open(self.Filename, mode = 'rb')
-        else: 
-            datafile = open(self.Filename, "rb")
+            datafile = fs.open(datafile, mode='rb')
+            if datafile is not None:
+                print("remote load successful")
+            else:
+                print("remote load failed")
+        except:
+            print("file could not be found, see error message")
             
 
         inbuff = datafile.read()


### PR DESCRIPTION
instead of a remote_load arg, always try remotely loading if local file load fails using a try-except statement. This can be propagated through all classes to potentially remove the need for the remote_load arg. I find it very easy to forget that default remote_load=False means that the code will fail with a type error.